### PR TITLE
impr(M-14082): inlcude m(t,j)s in eslint config

### DIFF
--- a/src/configs/mobal-imports-config.js
+++ b/src/configs/mobal-imports-config.js
@@ -13,6 +13,7 @@ const config = {
             '.mjs',
             '.ts',
             '.tsx',
+            '.mts',
         ],
         'import/core-modules': [],
         'import/ignore': [

--- a/src/configs/mobal-jest-config.js
+++ b/src/configs/mobal-jest-config.js
@@ -9,10 +9,10 @@ const configs = [
         },
         // update this to match your test files
         files: [
-            '**/__mocks__/*.{j,t}s',
-            'tests/**/*.spec.{j,t}s?(x)',
-            'tests/**/*.{j,t}s?(x)',
-            '**/__tests__/*.{j,t}s?(x)',
+            '**/__mocks__/*.{j,t,mj,mt}s',
+            'tests/**/*.spec.{j,t,mj,mt}s?(x)',
+            'tests/**/*.{j,t,mj,mt}s?(x)',
+            '**/__tests__/*.{j,t,mj,mt}s?(x)',
         ],
         languageOptions: {
             globals: {

--- a/src/configs/mobal-storybook-config.js
+++ b/src/configs/mobal-storybook-config.js
@@ -5,7 +5,7 @@ const config = {
         import: importPlugin,
     },
     files: [
-        'src/**/*stories.{j,t}s',
+        'src/**/*stories.{j,t,mj,mt}s',
     ],
     rules: {
         'import/no-extraneous-dependencies': 'off',

--- a/src/configs/rules/mobal-import-rules.js
+++ b/src/configs/rules/mobal-import-rules.js
@@ -8,6 +8,7 @@ export default {
             'jsx': 'never',
             'ts': 'never',
             'tsx': 'never',
+            'mts': 'never',
         },
     ],
     'import/no-unresolved': [


### PR DESCRIPTION
we will add new configs for website build, this changes will help to improve linting there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended ESLint and Jest configurations to support `.mts` (TypeScript module) file extensions alongside existing JavaScript and TypeScript formats. Updated glob patterns for imports, testing, and Storybook to ensure consistent linting and configuration coverage across all supported file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->