### PR TITLE
refactor(M-14171): vue-agnostic mobal.configs.javascript preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,17 @@ export default defineConfigWithVueTs(
 
 provided configs:
 
-* vue config
+* vue config (vue + js/ts rules + parser via `defineConfigWithVueTs`)
 ```
 mobal.configs.vue
 ```
-* basic js/ts config
+* basic js/ts config (vue-coupled, kept for backwards compat with `mobal.configs.vue`)
 ```
 mobal.configs.base
+```
+* vue-agnostic js/ts config (rules only — no parser/plugin; consumer wires tseslint)
+```
+mobal.configs.javascript
 ```
 * basic imports style
 ```
@@ -92,6 +96,32 @@ mobal.configs.accessability
 ``` 
 mobal.configs.vueI18n
 ```
+
+### TS-only / Node service usage
+
+For repos without Vue (Cloudflare Workers, plain Node services), wire tseslint
+yourself and add `mobal.configs.javascript` on top:
+
+```js
+// eslint.config.mjs
+import js from '@eslint/js'
+import mobal from 'eslint-plugin-mobal'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+    { ignores: ['node_modules/', 'dist/'] },
+    js.configs.recommended,
+    ...tseslint.configs.recommended,
+    ...mobal.configs.javascript,
+    ...mobal.configs.imports,
+)
+```
+
+`mobal.configs.javascript` only ships rules and helper plugins (import,
+stylistic, etc.) — the consumer registers `@typescript-eslint`'s parser and
+plugin via `tseslint.config()` + `tseslint.configs.recommended`. This avoids
+double-plugin-registration errors when mobal's preset is composed with other
+TS configs.
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eslint-plugin-mobal",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eslint-plugin-mobal",
-            "version": "1.5.2",
+            "version": "1.6.0",
             "license": "ISC",
             "dependencies": {
                 "@intlify/eslint-plugin-vue-i18n": "^4.3.0",
@@ -21,6 +21,7 @@
                 "eslint-plugin-vue": "^10.8.0",
                 "eslint-plugin-vuejs-accessibility": "^2.5.0",
                 "globals": "^17.4.0",
+                "typescript-eslint": "^8.57.2",
                 "vue-eslint-parser": "^10.4.0"
             },
             "devDependencies": {
@@ -517,19 +518,19 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
-            "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+            "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/type-utils": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
+                "@typescript-eslint/scope-manager": "8.59.1",
+                "@typescript-eslint/type-utils": "8.59.1",
+                "@typescript-eslint/utils": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -539,9 +540,9 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.57.1",
+                "@typescript-eslint/parser": "^8.59.1",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -554,15 +555,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
-            "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+            "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.57.2",
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/typescript-estree": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2",
+                "@typescript-eslint/scope-manager": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/typescript-estree": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -574,176 +575,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
-            "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.57.2",
-                "@typescript-eslint/types": "^8.57.2",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
-            "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
-            "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-            "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
-            "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.57.2",
-                "@typescript-eslint/tsconfig-utils": "8.57.2",
-                "@typescript-eslint/types": "8.57.2",
-                "@typescript-eslint/visitor-keys": "8.57.2",
-                "debug": "^4.4.3",
-                "minimatch": "^10.2.2",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.57.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
-            "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.57.2",
-                "eslint-visitor-keys": "^5.0.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
-            "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+            "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.57.1",
-                "@typescript-eslint/types": "^8.57.1",
+                "@typescript-eslint/tsconfig-utils": "^8.59.1",
+                "@typescript-eslint/types": "^8.59.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -754,17 +596,17 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
-            "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+            "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1"
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -775,9 +617,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
-            "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+            "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -787,20 +629,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
-            "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+            "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/typescript-estree": "8.59.1",
+                "@typescript-eslint/utils": "8.59.1",
                 "debug": "^4.4.3",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -811,13 +653,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
-            "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+            "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -828,20 +670,20 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
-            "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+            "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.57.1",
-                "@typescript-eslint/tsconfig-utils": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
+                "@typescript-eslint/project-service": "8.59.1",
+                "@typescript-eslint/tsconfig-utils": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -851,7 +693,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
@@ -864,9 +706,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
@@ -876,12 +718,12 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -891,15 +733,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
-            "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+            "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1"
+                "@typescript-eslint/scope-manager": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/typescript-estree": "8.59.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -910,16 +752,16 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
-            "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+            "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/types": "8.59.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -4422,9 +4264,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.12"
@@ -4546,15 +4388,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
-            "integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+            "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.57.1",
-                "@typescript-eslint/parser": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/utils": "8.57.1"
+                "@typescript-eslint/eslint-plugin": "8.59.1",
+                "@typescript-eslint/parser": "8.59.1",
+                "@typescript-eslint/typescript-estree": "8.59.1",
+                "@typescript-eslint/utils": "8.59.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4565,31 +4407,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
-            "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "8.57.1",
-                "@typescript-eslint/types": "8.57.1",
-                "@typescript-eslint/typescript-estree": "8.57.1",
-                "@typescript-eslint/visitor-keys": "8.57.1",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
                 "eslint-plugin-vue": "^10.8.0",
                 "eslint-plugin-vuejs-accessibility": "^2.5.0",
                 "globals": "^17.4.0",
-                "typescript-eslint": "^8.57.2",
                 "vue-eslint-parser": "^10.4.0"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-mobal",
-    "version": "1.5.3",
+    "version": "1.6.0",
     "description": "Mobal eslint configs and rules",
     "scripts": {
         "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "eslint-plugin-vue": "^10.8.0",
         "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "globals": "^17.4.0",
-        "typescript-eslint": "^8.57.2",
         "vue-eslint-parser": "^10.4.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "eslint-plugin-vue": "^10.8.0",
         "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "globals": "^17.4.0",
+        "typescript-eslint": "^8.57.2",
         "vue-eslint-parser": "^10.4.0"
     },
     "devDependencies": {

--- a/src/configs/mobal-base-config.js
+++ b/src/configs/mobal-base-config.js
@@ -1,29 +1,13 @@
-import globals from 'globals'
 import { defineConfigWithVueTs } from '@vue/eslint-config-typescript'
-import stylistic from '@stylistic/eslint-plugin'
-import newlineDestructuring from 'eslint-plugin-newline-destructuring'
-import importNewlines from 'eslint-plugin-import-newlines'
-import importPlugin from 'eslint-plugin-import'
 
-import baseJsRules from './rules/mobal-basic-js-rules.js'
-import flavorRules from './rules/mobal-flavor-rules.js'
+import javascriptConfig from './mobal-javascript-config.js'
+import vueRules from './rules/mobal-vue-rules.js'
 
 const config = defineConfigWithVueTs({
-    extends: [],
-    plugins: {
-        'import-newlines': importNewlines,
-        'import': importPlugin,
-        'newline-destructuring': newlineDestructuring,
-        '@stylistic': stylistic,
-    },
-    languageOptions: {
-        globals: {
-            ...globals.browser,
-        },
-    },
+    ...javascriptConfig,
     rules: {
-        ...baseJsRules,
-        ...flavorRules,
+        ...javascriptConfig.rules,
+        ...vueRules,
     },
 })[0]
 

--- a/src/configs/mobal-javascript-config.js
+++ b/src/configs/mobal-javascript-config.js
@@ -1,0 +1,28 @@
+import globals from 'globals'
+import stylistic from '@stylistic/eslint-plugin'
+import newlineDestructuring from 'eslint-plugin-newline-destructuring'
+import importNewlines from 'eslint-plugin-import-newlines'
+import importPlugin from 'eslint-plugin-import'
+
+import baseJsRules from './rules/mobal-basic-js-rules.js'
+import flavorJsRules from './rules/mobal-flavor-js-rules.js'
+
+const config = {
+    plugins: {
+        'import-newlines': importNewlines,
+        'import': importPlugin,
+        'newline-destructuring': newlineDestructuring,
+        '@stylistic': stylistic,
+    },
+    languageOptions: {
+        globals: {
+            ...globals.browser,
+        },
+    },
+    rules: {
+        ...baseJsRules,
+        ...flavorJsRules,
+    },
+}
+
+export default config

--- a/src/configs/rules/mobal-flavor-js-rules.js
+++ b/src/configs/rules/mobal-flavor-js-rules.js
@@ -1,0 +1,26 @@
+import mobalBaseFlavourRules from './mobal-base-flavour-rules.js'
+import mobalStylisticRules from './mobal-stylistic-rules.js'
+
+export default {
+    ...mobalBaseFlavourRules,
+    ...mobalStylisticRules,
+    '@typescript-eslint/no-shadow': ['error'],
+    '@typescript-eslint/ban-ts-comment': [
+        'error',
+        {
+            'ts-ignore': 'allow-with-description',
+            'minimumDescriptionLength': 10,
+        },
+    ],
+    '@typescript-eslint/no-unnecessary-condition': 'error',
+    '@typescript-eslint/no-var-requires': 'error',
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+    '@typescript-eslint/no-unused-vars': ['error', {
+        'argsIgnorePattern': '^_',
+        'varsIgnorePattern': '^_',
+    }],
+    '@typescript-eslint/no-non-null-assertion': 'error',
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/consistent-indexed-object-style': ['error', 'index-signature'],
+    '@typescript-eslint/no-duplicate-enum-values': 'warn',
+}

--- a/src/configs/rules/mobal-flavor-rules.js
+++ b/src/configs/rules/mobal-flavor-rules.js
@@ -1,28 +1,7 @@
-import mobalBaseFlavourRules from './mobal-base-flavour-rules.js'
-import mobalStylisticRules from './mobal-stylistic-rules.js'
+import jsRules from './mobal-flavor-js-rules.js'
 import vueRules from './mobal-vue-rules.js'
 
 export default {
-    ...mobalBaseFlavourRules,
-    ...mobalStylisticRules,
-    '@typescript-eslint/no-shadow': ['error'],
-    '@typescript-eslint/ban-ts-comment': [
-        'error',
-        {
-            'ts-ignore': 'allow-with-description',
-            'minimumDescriptionLength': 10,
-        },
-    ],
-    '@typescript-eslint/no-unnecessary-condition': 'error',
-    '@typescript-eslint/no-var-requires': 'error',
-    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
-    '@typescript-eslint/no-unused-vars': ['error', {
-        'argsIgnorePattern': '^_',
-        'varsIgnorePattern': '^_',
-    }],
-    '@typescript-eslint/no-non-null-assertion': 'error',
-    '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/consistent-indexed-object-style': ['error', 'index-signature'],
-    '@typescript-eslint/no-duplicate-enum-values': 'warn',
+    ...jsRules,
     ...vueRules,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import path from 'path'
 import './dirname-polyfill.js'
 import rules from './rules/index.js'
 import baseConfigRaw from './configs/mobal-base-config.js'
+import javascriptConfigRaw from './configs/mobal-javascript-config.js'
 import importsConfig from './configs/mobal-imports-config.js'
 import vueAccessabilityConfig from './configs/mobal-vue-accessability-config.js'
 import jestConfigs from './configs/mobal-jest-config.js'
@@ -32,8 +33,17 @@ const baseConfig = {
     },
 }
 
+const javascriptConfig = {
+    ...javascriptConfigRaw,
+    plugins: {
+        ...javascriptConfigRaw.plugins,
+        mobal: plugin,
+    },
+}
+
 Object.assign(plugin.configs, {
     base: [baseConfig],
+    javascript: [javascriptConfig],
     imports: [importsConfig],
     accessability: [vueAccessabilityConfig],
     vue: [

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 
+import tseslint from 'typescript-eslint'
+
 import './dirname-polyfill.js'
 import rules from './rules/index.js'
 import baseConfigRaw from './configs/mobal-base-config.js'
@@ -43,7 +45,10 @@ const javascriptConfig = {
 
 Object.assign(plugin.configs, {
     base: [baseConfig],
-    javascript: [javascriptConfig],
+    javascript: [
+        ...tseslint.configs.recommended,
+        javascriptConfig,
+    ],
     imports: [importsConfig],
     accessability: [vueAccessabilityConfig],
     vue: [

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 
-import tseslint from 'typescript-eslint'
-
 import './dirname-polyfill.js'
 import rules from './rules/index.js'
 import baseConfigRaw from './configs/mobal-base-config.js'
@@ -45,10 +43,7 @@ const javascriptConfig = {
 
 Object.assign(plugin.configs, {
     base: [baseConfig],
-    javascript: [
-        ...tseslint.configs.recommended,
-        javascriptConfig,
-    ],
+    javascript: [javascriptConfig],
     imports: [importsConfig],
     accessability: [vueAccessabilityConfig],
     vue: [


### PR DESCRIPTION
## Summary

- Extracts the JS/TS half of `mobal-flavor-rules.js` into `mobal-flavor-js-rules.js`.
- Rewrites `mobal-flavor-rules.js` as a thin composition of `flavor-js-rules` + `vue-rules` — same rules out, no behavior change for `base`/`vue`.
- Adds `mobal-javascript-config.js`: a pure flat config (no `defineConfigWithVueTs`) using `basic-js-rules` + `flavor-js-rules`.
- Registers it as `mobal.configs.javascript` alongside the existing `base`/`vue`/etc. presets — backwards compatible.

Motivation: stacks without Vue (Cloudflare Worker for LLM visibility, future Node services) can use `mobal.configs.javascript` without needing to register `eslint-plugin-vue` to avoid \`could not find plugin "vue"\` load errors.

## Test plan

- [x] Plugin's own mocha tests pass.
- [x] Linked into the new worker repo via \`npm link\` — \`mobal.configs.javascript\` loads cleanly with no vue-plugin errors.
- [x] Linked into app-ui via \`npm link\` — \`npm run lint:fast\` reports the same 0 errors / 69 warnings as before (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated JavaScript configuration preset and registered it alongside existing presets.
  * Enforced stricter TypeScript linting rules (stronger type checks, no-shadowing, restricted non-null assertions/any, duplicate-enum warnings).

* **Refactor**
  * Reorganized lint configuration into modular, composable pieces for clearer layering and easier maintenance.

* **Documentation**
  * Updated README with the new preset, usage guidance, and TS/Node composition examples.

* **Chore**
  * Bumped package version to 1.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->